### PR TITLE
feat: no more /docs link

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -19,7 +19,7 @@ This guide will introduce you to NEAR, Rust, and RAEN.
 
 # Getting Set Up
 
-[Install RAEN](https://raen.dev/docs/guide/installation.html), then clone the examples repository to follow along:
+[Install RAEN](https://github.com/raendev/raen), then clone the examples repository to follow along:
 
 ```bash
 git clone --depth 1 --branch v0.0.3 https://github.com/raendev/examples.git --recursive


### PR DESCRIPTION
Install instructions live at github.com/raendev/raen since https://github.com/raendev/raen/pull/9